### PR TITLE
parallelize tsdr and sleep

### DIFF
--- a/experiments/argowf-analytics.cue
+++ b/experiments/argowf-analytics.cue
@@ -4,6 +4,7 @@ metadata: generateName: "argowf-analytics-"
 spec: {
 	entrypoint:         "argowf-analytics"
 	serviceAccountName: "argo-chaos"
+	nodeSelector: "cloud.google.com/gke-nodepool": "analytics-pool"
 	arguments: parameters: [{
 		name: "gcsBucket"
 		value: "microservices-demo-artifacts"
@@ -16,17 +17,10 @@ spec: {
 	}, {
 		name: "tsdrMethod"
 		value: "tsifter"
-	}, {
-		name: "gkeNodePool"
-		value: "analytics-pool"
-	} ]
+	}]
 	parallelism: 1
 	templates: [{
 		name: "argowf-analytics"
-		nodeSelector: {
-			"beta.kubernetes.io/arch": "linux"
-			"cloud.google.com/gke-nodepool": "{{workflow.parameters.gkeNodePool}}"
-		}
 		steps: [ [ {
 			name: "list-files"
 			template: "list-metrics-files"

--- a/experiments/argowf.cue
+++ b/experiments/argowf.cue
@@ -410,6 +410,9 @@ spec: {
 	}, {
 		// Note the following duplicate code in argowf-analytics.cue. 
 		name: "run-tsdr-by-method"
+		nodeSelector: {
+			"cloud.google.com/gke-nodepool": "analytics-pool"
+		}
 		inputs: {
 			parameters: [{
 				name: "tsdrMethod"


### PR DESCRIPTION
- argo: parallelize tsdr and sleep steps
- argo: set nodeSelector as analytics-pool in run-tsdr template
- argo: fix sleep execution not being parallelized
- argo: move nodeSelector from template-level to workflow-level in analytics
